### PR TITLE
fix searchable_first_name reference in queries

### DIFF
--- a/alexandria/users/views/ajax.py
+++ b/alexandria/users/views/ajax.py
@@ -37,8 +37,9 @@ def item_search(request, term):
 @permission_or_none("users.read_patron_account")
 def patron_search(request, term):
     return User.objects.filter(
-        Q(searchable_first_name__icontains=term)
-        | Q(searchable_last_name__icontains=term)
+        Q(searchable_legal_first_name__icontains=term)
+        | Q(searchable_legal_last_name__icontains=term)
+        | Q(searchable_chosen_first_name__icontains=term)
         | Q(card_number=term),
         is_active=True,
         host=request.host,

--- a/alexandria/users/views/patron_management.py
+++ b/alexandria/users/views/patron_management.py
@@ -26,8 +26,8 @@ def patron_management(request: Request):
         search_text = clean_text(search_text)
         for word in search_text.split():
             results = results.filter(
-                Q(searchable_first_name__icontains=word)
-                | Q(searchable_last_name__icontains=word)
+                Q(searchable_legal_first_name__icontains=word)
+                | Q(searchable_legal_last_name__icontains=word)
                 | Q(searchable_chosen_first_name__icontains=word)
                 | Q(title__icontains=word)
                 | Q(card_number__icontains=word)

--- a/alexandria/users/views/staff_management.py
+++ b/alexandria/users/views/staff_management.py
@@ -26,8 +26,8 @@ def staff_management(request: Request):
         search_text = clean_text(search_text)
         for word in search_text.split():
             results = results.filter(
-                Q(searchable_first_name__icontains=word)
-                | Q(searchable_last_name__icontains=word)
+                Q(searchable_legal_first_name__icontains=word)
+                | Q(searchable_legal_last_name__icontains=word)
                 | Q(searchable_chosen_first_name__icontains=word)
                 | Q(title__icontains=word)
                 | Q(card_number__icontains=word)


### PR DESCRIPTION
Relevant issue: N/A

## Description:

Found an issue where `searchable_first_name` was updated to `searchable_legal_first_name` but the queries apparently were not updated to match.

## Testing Instructions:

Try the search.

## Checklist:

- [ ] Code Quality
- [ ] Pep-8
- [ ] Tests (if applicable)
- [ ] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
